### PR TITLE
Add multiple seed ik solver

### DIFF
--- a/dynamic_payload_analysis_core/dynamic_payload_analysis_core/core.py
+++ b/dynamic_payload_analysis_core/dynamic_payload_analysis_core/core.py
@@ -45,9 +45,9 @@ class TorqueCalculator:
                 robot_description.write_xml_file(temp_file.name)
 
             # Get the absolute path of the current script
-            path = temp_file
+            file_path = temp_file.name
 
-            with open(path, "rb",) as f:
+            with open(file_path, "rb",) as f:
                 robot_description = f.read()
             # create model from the urdf string
             self.model = pin.buildModelFromXML(robot_description)
@@ -58,7 +58,7 @@ class TorqueCalculator:
             self.root_name = self.get_root_joint_name(robot_description)
 
             # create geometry model from the urdf file
-            self.geom_model = pin.buildGeomFromUrdf(self.model,temp_file.absolute(),pin.GeometryType.COLLISION)
+            self.geom_model = pin.buildGeomFromUrdf(self.model, file_path, pin.GeometryType.COLLISION)
             # Add collisition pairs
             self.geom_model.addAllCollisionPairs()
 

--- a/dynamic_payload_analysis_core/dynamic_payload_analysis_core/core.py
+++ b/dynamic_payload_analysis_core/dynamic_payload_analysis_core/core.py
@@ -611,7 +611,7 @@ class TorqueCalculator:
             
         return False
         
-    def compute_maximum_payloads(self, configs : np.ndarray[Configuration]) -> np.ndarray:
+    def compute_maximum_payloads(self, configs : np.ndarray[Configuration]):
         """
         Compute the maximum payload for each provided configuration.
         

--- a/dynamic_payload_analysis_ros/dynamic_payload_analysis_ros/menu_visual.py
+++ b/dynamic_payload_analysis_ros/dynamic_payload_analysis_ros/menu_visual.py
@@ -317,6 +317,8 @@ class MenuPayload():
         Args:
             configuration (np.ndarray): Array of configuration to be displayed in the dropdown.
         """
+        if configuration is None:
+            return
 
         if configuration.size == 0:
             return

--- a/dynamic_payload_analysis_ros/dynamic_payload_analysis_ros/rviz_visualization_menu.py
+++ b/dynamic_payload_analysis_ros/dynamic_payload_analysis_ros/rviz_visualization_menu.py
@@ -279,7 +279,7 @@ class RobotDescriptionSubscriber(Node):
                 self.valid_configurations = self.robot_handler.get_valid_workspace(range = self.range_ik,resolution= self.resolution_ik, masses = self.masses, checked_frames = self.checked_frames)
 
                 # compute the maximum payloads for the valid configurations
-                self.valid_configurations = self.robot_handler.compute_maximum_payloads(self.valid_configurations)
+                self.robot_handler.compute_maximum_payloads(self.valid_configurations)
 
                 # publish the analyzed points in the workspace area
                 self.publisher_analyzed_point_markers()


### PR DESCRIPTION
Previously, workspace IK used the previous valid configuration as the main starting point. This could trap the solver in a local branch and miss reachable configurations for some robots (example UR robots ). 
The new approach adds generic multi-seed fallback generation, scoped to the selected subtree, so the solver has more chances to converge to a valid configuration.
@saikishor 